### PR TITLE
Expand default service roster to 10 modules

### DIFF
--- a/CONFIGURATION_COMPLETE.md
+++ b/CONFIGURATION_COMPLETE.md
@@ -144,7 +144,7 @@ docker compose up -d kafka ev-central
 **Machine B** (Charging Points):
 ```bash
 export KAFKA_BOOTSTRAP=<machine-a-ip>:9092
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 **Use case**: Distributed lab testing
@@ -166,10 +166,10 @@ Any combination of services can be deployed:
 docker compose up -d ev-central
 
 # Just CPs
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 
 # Just Driver
-docker compose up -d ev-driver
+docker compose up -d ev-driver ev-driver-2
 ```
 
 ---

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -112,7 +112,7 @@ export KAFKA_BOOTSTRAP=<machine1-ip>:9092
 export CENTRAL_HOST=<machine1-ip>
 
 # Deploy only charging points
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 #### Scenario B: All services use shared remote Kafka
@@ -131,14 +131,14 @@ docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-central
 ```bash
 export KAFKA_BOOTSTRAP=kafka.lab.local:9092
 export CENTRAL_HOST=<machine1-ip>
-docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 **Machine 3 (Driver)**:
 
 ```bash
 export KAFKA_BOOTSTRAP=kafka.lab.local:9092
-docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver
+docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver ev-driver-2
 ```
 
 ---
@@ -348,7 +348,7 @@ CENTRAL_HOST=192.168.1.10
 EOF
 
 # Start charging points
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 
 # Verify
 docker compose ps
@@ -367,7 +367,7 @@ KAFKA_BOOTSTRAP=192.168.1.10:9092
 EOF
 
 # Start driver
-docker compose up -d ev-driver
+docker compose up -d ev-driver ev-driver-2
 
 # Verify
 docker compose logs ev-driver

--- a/DEPLOYMENT_SUMMARY.md
+++ b/DEPLOYMENT_SUMMARY.md
@@ -128,7 +128,7 @@ docker compose up -d kafka ev-central
 **Machine 2** (192.168.1.11):
 ```bash
 export KAFKA_BOOTSTRAP=192.168.1.10:9092
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 #### Scenario B: Shared Remote Kafka, Services Distributed
@@ -146,13 +146,13 @@ docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-central
 export KAFKA_BOOTSTRAP=kafka.lab.edu:9092
 export CENTRAL_HOST=<machine1-ip>
 docker compose -f docker/docker-compose.remote-kafka.yml up -d \
-  ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+  ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 **Machine 3** (Driver):
 ```bash
 export KAFKA_BOOTSTRAP=kafka.lab.edu:9092
-docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver
+docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver ev-driver-2
 ```
 
 **Requirements**:

--- a/LAB_DEPLOYMENT_READY.md
+++ b/LAB_DEPLOYMENT_READY.md
@@ -14,6 +14,7 @@ The EV Charging Simulation system is now fully configured for deployment **witho
 - **Interactive script**: `./deploy.sh` with menu-driven options
 - **Make targets**: `make up`, `make remote-kafka`, `make lab-deploy`
 - **No manual compilation required**
+- **Service roster**: 10 services (Kafka, Central, 3×CP Engines, 3×CP Monitors, 2×Drivers) ready for grading stress tests
 
 ### ✅ Multiple Deployment Scenarios
 
@@ -84,7 +85,7 @@ cd ev-charging-simulation
 export KAFKA_BOOTSTRAP=192.168.1.10:9092
 
 # Start only charging point services
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 
 # Verify
 docker compose ps
@@ -133,14 +134,41 @@ docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-central
 export KAFKA_BOOTSTRAP=kafka.lab.edu:9092
 export CENTRAL_HOST=<machine1-ip>
 docker compose -f docker/docker-compose.remote-kafka.yml up -d \
-  ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+  ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 \
+  ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 **Machine 3** (Driver Client):
 ```bash
 export KAFKA_BOOTSTRAP=kafka.lab.edu:9092
-docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver
+docker compose -f docker/docker-compose.remote-kafka.yml up -d ev-driver ev-driver-2
 ```
+
+---
+
+## Hands-Off Classroom Demonstration
+
+To satisfy the grading requirement of launching the entire solution without additional interaction:
+
+1. **Start everything at once** (on a single node or orchestrating nodes with shared compose file):
+   ```bash
+   docker compose up -d
+   ```
+
+2. **Observe the system** without touching it further:
+   ```bash
+   docker compose logs -f ev-central ev-driver ev-driver-2
+   ```
+   - Central logs show CP registrations and session orchestration.
+   - Both drivers emit charging requests against multiple CPs.
+
+3. **Optional projector view**: open the Central dashboard at `http://<central-host>:8000` to watch CP state changes and driver sessions unfold.
+
+4. **Health confirmation** (non-interactive once running):
+   ```bash
+   make verify
+   ```
+   The script checks all 10 services, Kafka topics, and HTTP/TCP endpoints without needing code changes or rebuilds.
 
 ---
 
@@ -175,10 +203,10 @@ Each service can be deployed separately:
 docker compose up -d ev-central
 
 # Just Charging Points
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 
 # Just Driver
-docker compose up -d ev-driver
+docker compose up -d ev-driver ev-driver-2
 
 # Just Kafka
 docker compose up -d kafka
@@ -355,7 +383,7 @@ docker compose -f docker/docker-compose.remote-kafka.yml up -d
 docker compose up -d ev-central
 
 # Charging Points only
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 ### Check Status

--- a/Makefile
+++ b/Makefile
@@ -63,17 +63,17 @@ lab-deploy:
 	@echo "Lab deployment mode"
 	@echo "Select components to deploy:"
 	@echo "  1) Central only"
-	@echo "  2) Charging Points only"  
-	@echo "  3) Driver only"
-	@echo "  4) Central + Charging Points"
-	@read -p "Enter choice [1-4]: " choice; \
-	case $$choice in \
-		1) docker compose up -d ev-central ;; \
-		2) docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2 ;; \
-		3) docker compose up -d ev-driver ;; \
-		4) docker compose up -d ev-central ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2 ;; \
-		*) echo "Invalid choice" ;; \
-	esac
+        @echo "  2) Charging Points only"
+        @echo "  3) Driver only"
+        @echo "  4) Central + Charging Points"
+        @read -p "Enter choice [1-4]: " choice; \
+        case $$choice in \
+                1) docker compose up -d ev-central ;; \
+                2) docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3 ;; \
+                3) docker compose up -d ev-driver ev-driver-2 ;; \
+                4) docker compose up -d ev-central ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3 ;; \
+                *) echo "Invalid choice" ;; \
+        esac
 
 down:
 	@echo "Stopping all services..."
@@ -117,9 +117,13 @@ local-run:
 	python -m evcharging.apps.ev_central.main &
 	sleep 2
 	python -m evcharging.apps.ev_cp_e.main --cp-id CP-001 --health-port 8001 &
-	python -m evcharging.apps.ev_cp_e.main --cp-id CP-002 --health-port 8002 &
-	sleep 2
-	python -m evcharging.apps.ev_cp_m.main --cp-id CP-001 --cp-e-port 8001 &
-	python -m evcharging.apps.ev_cp_m.main --cp-id CP-002 --cp-e-port 8002 &
-	sleep 2
-	python -m evcharging.apps.ev_driver.main --driver-id driver-alice --requests-file requests.txt
+        python -m evcharging.apps.ev_cp_e.main --cp-id CP-002 --health-port 8002 &
+        python -m evcharging.apps.ev_cp_e.main --cp-id CP-003 --health-port 8003 &
+        sleep 2
+        python -m evcharging.apps.ev_cp_m.main --cp-id CP-001 --cp-e-port 8001 &
+        python -m evcharging.apps.ev_cp_m.main --cp-id CP-002 --cp-e-port 8002 &
+        python -m evcharging.apps.ev_cp_m.main --cp-id CP-003 --cp-e-port 8003 &
+        sleep 2
+        python -m evcharging.apps.ev_driver.main --driver-id driver-alice --requests-file requests.txt &
+        python -m evcharging.apps.ev_driver.main --driver-id driver-bob --requests-file requests.txt &
+        wait

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -198,7 +198,7 @@ hostname -I
 export KAFKA_BOOTSTRAP=<machine1-ip>:9092
 
 # Run charging points
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 See [DEPLOYMENT_GUIDE.md](DEPLOYMENT_GUIDE.md) for detailed lab instructions.

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ docker compose up -d kafka ev-central
 **Machine B** (Charging Points):
 ```bash
 export KAFKA_BOOTSTRAP=<machine-a-ip>:9092
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 #### 4. Interactive Deployment

--- a/deploy.sh
+++ b/deploy.sh
@@ -158,15 +158,20 @@ deploy_lab() {
             ;;
         2)
             print_info "Deploying Charging Points only..."
-            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d \
+                ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 \
+                ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
             ;;
         3)
             print_info "Deploying Driver only..."
-            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d ev-driver
+            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d ev-driver ev-driver-2
             ;;
         4)
             print_info "Deploying Central and Charging Points..."
-            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d ev-central ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+            KAFKA_BOOTSTRAP=$kafka_addr docker compose up -d \
+                ev-central \
+                ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 \
+                ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
             ;;
         *)
             print_error "Invalid choice"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,26 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Engine 3
+  ev-cp-e-3:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.cp_e
+    container_name: ev-cp-e-3
+    environment:
+      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_CP_ID: CP-003
+      CP_ENGINE_HEALTH_PORT: 8001
+      CP_ENGINE_LOG_LEVEL: INFO
+      CP_ENGINE_KW_RATE: 11.0
+      CP_ENGINE_EURO_RATE: 0.28
+    depends_on:
+      kafka:
+        condition: service_healthy
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # Charging Point Monitor 1
   ev-cp-m-1:
     build:
@@ -136,6 +156,27 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Monitor 3
+  ev-cp-m-3:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.cp_m
+    container_name: ev-cp-m-3
+    environment:
+      CP_MONITOR_CP_ID: CP-003
+      CP_MONITOR_CP_E_HOST: ev-cp-e-3
+      CP_MONITOR_CP_E_PORT: 8001
+      CP_MONITOR_CENTRAL_HOST: ev-central
+      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_HEALTH_INTERVAL: 1.0
+      CP_MONITOR_LOG_LEVEL: INFO
+    depends_on:
+      - ev-central
+      - ev-cp-e-3
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # EV Driver Client
   ev-driver:
     build:
@@ -146,6 +187,28 @@ services:
       DRIVER_DRIVER_ID: driver-alice
       DRIVER_KAFKA_BOOTSTRAP: kafka:9092
       DRIVER_REQUEST_INTERVAL: 4.0
+      DRIVER_LOG_LEVEL: INFO
+    volumes:
+      - ./requests.txt:/app/requests.txt:ro
+    depends_on:
+      kafka:
+        condition: service_healthy
+      ev-central:
+        condition: service_started
+    networks:
+      - evcharging-network
+
+  # EV Driver Client (secondary)
+  ev-driver-2:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.driver
+    container_name: ev-driver-2
+    environment:
+      DRIVER_DRIVER_ID: driver-bob
+      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_REQUEST_INTERVAL: 5.0
+      DRIVER_REQUESTS_FILE: /app/requests.txt
       DRIVER_LOG_LEVEL: INFO
     volumes:
       - ./requests.txt:/app/requests.txt:ro

--- a/docker/README.md
+++ b/docker/README.md
@@ -254,7 +254,7 @@ hostname -I  # Note this IP
 ```bash
 cd ..
 export KAFKA_BOOTSTRAP=<machine1-ip>:9092
-docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-m-1 ev-cp-m-2
+docker compose up -d ev-cp-e-1 ev-cp-e-2 ev-cp-e-3 ev-cp-m-1 ev-cp-m-2 ev-cp-m-3
 ```
 
 ### Scenario 3: Remote Kafka

--- a/docker/docker-compose.remote-kafka.yml
+++ b/docker/docker-compose.remote-kafka.yml
@@ -56,6 +56,23 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Engine 3
+  ev-cp-e-3:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cp_e
+    container_name: ev-cp-e-3
+    environment:
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
+      CP_ENGINE_CP_ID: CP-003
+      CP_ENGINE_HEALTH_PORT: 8001
+      CP_ENGINE_LOG_LEVEL: INFO
+      CP_ENGINE_KW_RATE: 11.0
+      CP_ENGINE_EURO_RATE: 0.28
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # Charging Point Monitor 1
   ev-cp-m-1:
     build:
@@ -98,6 +115,27 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Monitor 3
+  ev-cp-m-3:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cp_m
+    container_name: ev-cp-m-3
+    environment:
+      CP_MONITOR_CP_ID: CP-003
+      CP_MONITOR_CP_E_HOST: ev-cp-e-3
+      CP_MONITOR_CP_E_PORT: 8001
+      CP_MONITOR_CENTRAL_HOST: ev-central
+      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_HEALTH_INTERVAL: 1.0
+      CP_MONITOR_LOG_LEVEL: INFO
+    depends_on:
+      - ev-central
+      - ev-cp-e-3
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # EV Driver Client
   ev-driver:
     build:
@@ -108,6 +146,25 @@ services:
       DRIVER_DRIVER_ID: driver-alice
       DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 4.0
+      DRIVER_LOG_LEVEL: INFO
+    volumes:
+      - ../requests.txt:/app/requests.txt:ro
+    depends_on:
+      - ev-central
+    networks:
+      - evcharging-network
+
+  # EV Driver Client (secondary)
+  ev-driver-2:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.driver
+    container_name: ev-driver-2
+    environment:
+      DRIVER_DRIVER_ID: driver-bob
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
+      DRIVER_REQUEST_INTERVAL: 5.0
+      DRIVER_REQUESTS_FILE: /app/requests.txt
       DRIVER_LOG_LEVEL: INFO
     volumes:
       - ../requests.txt:/app/requests.txt:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -93,6 +93,26 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Engine 3
+  ev-cp-e-3:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cp_e
+    container_name: ev-cp-e-3
+    environment:
+      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_CP_ID: CP-003
+      CP_ENGINE_HEALTH_PORT: 8001
+      CP_ENGINE_LOG_LEVEL: INFO
+      CP_ENGINE_KW_RATE: 11.0
+      CP_ENGINE_EURO_RATE: 0.28
+    depends_on:
+      kafka:
+        condition: service_healthy
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # Charging Point Monitor 1
   ev-cp-m-1:
     build:
@@ -135,6 +155,27 @@ services:
       - evcharging-network
     restart: unless-stopped
 
+  # Charging Point Monitor 3
+  ev-cp-m-3:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.cp_m
+    container_name: ev-cp-m-3
+    environment:
+      CP_MONITOR_CP_ID: CP-003
+      CP_MONITOR_CP_E_HOST: ev-cp-e-3
+      CP_MONITOR_CP_E_PORT: 8001
+      CP_MONITOR_CENTRAL_HOST: ev-central
+      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_HEALTH_INTERVAL: 1.0
+      CP_MONITOR_LOG_LEVEL: INFO
+    depends_on:
+      - ev-central
+      - ev-cp-e-3
+    networks:
+      - evcharging-network
+    restart: unless-stopped
+
   # EV Driver Client
   ev-driver:
     build:
@@ -145,6 +186,28 @@ services:
       DRIVER_DRIVER_ID: driver-alice
       DRIVER_KAFKA_BOOTSTRAP: kafka:9092
       DRIVER_REQUEST_INTERVAL: 4.0
+      DRIVER_LOG_LEVEL: INFO
+    volumes:
+      - ../requests.txt:/app/requests.txt:ro
+    depends_on:
+      kafka:
+        condition: service_healthy
+      ev-central:
+        condition: service_started
+    networks:
+      - evcharging-network
+
+  # EV Driver Client (secondary)
+  ev-driver-2:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.driver
+    container_name: ev-driver-2
+    environment:
+      DRIVER_DRIVER_ID: driver-bob
+      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_REQUEST_INTERVAL: 5.0
+      DRIVER_REQUESTS_FILE: /app/requests.txt
       DRIVER_LOG_LEVEL: INFO
     volumes:
       - ../requests.txt:/app/requests.txt:ro

--- a/verify.sh
+++ b/verify.sh
@@ -48,7 +48,18 @@ check_docker_services() {
     fi
     
     # Get list of expected services
-    local services=("kafka" "ev-central" "ev-cp-e-1" "ev-cp-e-2" "ev-cp-m-1" "ev-cp-m-2" "ev-driver")
+    local services=(
+        "kafka"
+        "ev-central"
+        "ev-cp-e-1"
+        "ev-cp-e-2"
+        "ev-cp-e-3"
+        "ev-cp-m-1"
+        "ev-cp-m-2"
+        "ev-cp-m-3"
+        "ev-driver"
+        "ev-driver-2"
+    )
     
     for service in "${services[@]}"; do
         if docker compose ps | grep -q "$service.*Up"; then
@@ -150,7 +161,7 @@ check_service_health() {
 check_logs() {
     print_header "Checking Logs for Errors"
     
-    local services=("ev-central" "ev-cp-e-1" "ev-cp-e-2")
+    local services=("ev-central" "ev-cp-e-1" "ev-cp-e-2" "ev-cp-e-3")
     
     for service in "${services[@]}"; do
         if docker compose ps | grep -q "$service.*Up"; then


### PR DESCRIPTION
## Summary
- expand all docker-compose variants to deploy three CP engines, three monitors, and two drivers by default so at least ten services are available for grading scenarios
- update automation tooling and lab documentation to reference the expanded service list and document a hands-off classroom demonstration flow
- extend verification and local-run helpers to monitor the additional services

## Testing
- python -m compileall evcharging

------
https://chatgpt.com/codex/tasks/task_e_68f92ddac9b08323bc6b903403a3f482