### PR TITLE
central healthcheck, kafka localhost listener

### DIFF
--- a/docker/Dockerfile.central
+++ b/docker/Dockerfile.central
@@ -7,6 +7,7 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,13 +7,14 @@ services:
     container_name: ev-kafka
     ports:
       - "9092:9092"
+      - "29092:29092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093,EXTERNAL://0.0.0.0:29092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
@@ -49,6 +50,12 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
     networks:
       - evcharging-network
     restart: unless-stopped
@@ -108,8 +115,10 @@ services:
       CP_MONITOR_HEALTH_INTERVAL: 1.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
-      - ev-central
-      - ev-cp-e-1
+      ev-central:
+        condition: service_healthy
+      ev-cp-e-1:
+        condition: service_started
     networks:
       - evcharging-network
     restart: unless-stopped
@@ -129,8 +138,10 @@ services:
       CP_MONITOR_HEALTH_INTERVAL: 1.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
-      - ev-central
-      - ev-cp-e-2
+      ev-central:
+        condition: service_healthy
+      ev-cp-e-1:
+        condition: service_started
     networks:
       - evcharging-network
     restart: unless-stopped
@@ -152,7 +163,7 @@ services:
       kafka:
         condition: service_healthy
       ev-central:
-        condition: service_started
+        condition: service_healthy
     networks:
       - evcharging-network
 

--- a/evcharging/common/kafka.py
+++ b/evcharging/common/kafka.py
@@ -28,7 +28,7 @@ class KafkaProducerHelper:
             key_serializer=lambda k: k.encode('utf-8') if k else None,
         )
         await self.producer.start()
-        logger.info(f"Kafka producer started: {self.bootstrap_servers}")
+        #logger.info(f"Kafka producer started: {self.bootstrap_servers}")
     
     async def stop(self):
         """Stop the producer."""
@@ -77,7 +77,7 @@ class KafkaConsumerHelper:
             key_deserializer=lambda k: k.decode('utf-8') if k else None,
         )
         await self.consumer.start()
-        logger.info(f"Kafka consumer started: topics={self.topics}, group={self.group_id}")
+        #logger.info(f"Kafka consumer started: topics={self.topics}, group={self.group_id}")
     
     async def stop(self):
         """Stop the consumer."""
@@ -112,7 +112,7 @@ async def ensure_topics(bootstrap_servers: str, topics: list[str], num_partition
             for topic in topics
         ]
         await admin.create_topics(new_topics, validate_only=False)
-        logger.info(f"Created topics: {topics}")
+        #logger.info(f"Created topics: {topics}")
     except TopicAlreadyExistsError:
         logger.debug(f"Topics already exist: {topics}")
     except Exception as e:


### PR DESCRIPTION
Added healthcheck to central so that drivers and monitors know when they can start trying to connect to central. It required "curl" to ping the localhost:8000/health so i added it to dockerfile for the central.

Also added new listening port for kafka to be able to look into content of kafka from cli