### PR TITLE
Allow configuring remote infrastructure hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - "8000:8000"  # HTTP Dashboard
       - "9999:9999"  # TCP Control
     environment:
-      CENTRAL_KAFKA_BOOTSTRAP: kafka:9092
+      CENTRAL_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CENTRAL_HTTP_PORT: 8000
       CENTRAL_LISTEN_PORT: 9999
       CENTRAL_LOG_LEVEL: INFO
@@ -95,7 +95,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-1
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-001
       CP_ENGINE_HEALTH_PORT: 8001
       CP_ENGINE_LOG_LEVEL: INFO
@@ -115,7 +115,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-2
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-002
       CP_ENGINE_HEALTH_PORT: 8002
       CP_ENGINE_LOG_LEVEL: INFO
@@ -135,7 +135,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-3
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-003
       CP_ENGINE_HEALTH_PORT: 8003
       CP_ENGINE_LOG_LEVEL: INFO
@@ -155,7 +155,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-4
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-004
       CP_ENGINE_HEALTH_PORT: 8004
       CP_ENGINE_LOG_LEVEL: INFO
@@ -175,7 +175,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-5
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-005
       CP_ENGINE_HEALTH_PORT: 8005
       CP_ENGINE_LOG_LEVEL: INFO
@@ -195,7 +195,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-6
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-006
       CP_ENGINE_HEALTH_PORT: 8006
       CP_ENGINE_LOG_LEVEL: INFO
@@ -215,7 +215,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-7
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-007
       CP_ENGINE_HEALTH_PORT: 8007
       CP_ENGINE_LOG_LEVEL: INFO
@@ -235,7 +235,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-8
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-008
       CP_ENGINE_HEALTH_PORT: 8008
       CP_ENGINE_LOG_LEVEL: INFO
@@ -255,7 +255,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-9
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-009
       CP_ENGINE_HEALTH_PORT: 8009
       CP_ENGINE_LOG_LEVEL: INFO
@@ -275,7 +275,7 @@ services:
       dockerfile: docker/Dockerfile.cp_e
     container_name: ev-cp-e-10
     environment:
-      CP_ENGINE_KAFKA_BOOTSTRAP: kafka:9092
+      CP_ENGINE_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       CP_ENGINE_CP_ID: CP-010
       CP_ENGINE_HEALTH_PORT: 8010
       CP_ENGINE_LOG_LEVEL: INFO
@@ -300,8 +300,8 @@ services:
       CP_MONITOR_CP_ID: CP-001
       CP_MONITOR_CP_E_HOST: ev-cp-e-1
       CP_MONITOR_CP_E_PORT: 8001
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -320,8 +320,8 @@ services:
       CP_MONITOR_CP_ID: CP-002
       CP_MONITOR_CP_E_HOST: ev-cp-e-2
       CP_MONITOR_CP_E_PORT: 8002
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -340,8 +340,8 @@ services:
       CP_MONITOR_CP_ID: CP-003
       CP_MONITOR_CP_E_HOST: ev-cp-e-3
       CP_MONITOR_CP_E_PORT: 8003
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -360,8 +360,8 @@ services:
       CP_MONITOR_CP_ID: CP-004
       CP_MONITOR_CP_E_HOST: ev-cp-e-4
       CP_MONITOR_CP_E_PORT: 8004
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -380,8 +380,8 @@ services:
       CP_MONITOR_CP_ID: CP-005
       CP_MONITOR_CP_E_HOST: ev-cp-e-5
       CP_MONITOR_CP_E_PORT: 8005
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -400,8 +400,8 @@ services:
       CP_MONITOR_CP_ID: CP-006
       CP_MONITOR_CP_E_HOST: ev-cp-e-6
       CP_MONITOR_CP_E_PORT: 8006
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -420,8 +420,8 @@ services:
       CP_MONITOR_CP_ID: CP-007
       CP_MONITOR_CP_E_HOST: ev-cp-e-7
       CP_MONITOR_CP_E_PORT: 8007
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -440,8 +440,8 @@ services:
       CP_MONITOR_CP_ID: CP-008
       CP_MONITOR_CP_E_HOST: ev-cp-e-8
       CP_MONITOR_CP_E_PORT: 8008
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -460,8 +460,8 @@ services:
       CP_MONITOR_CP_ID: CP-009
       CP_MONITOR_CP_E_HOST: ev-cp-e-9
       CP_MONITOR_CP_E_PORT: 8009
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -480,8 +480,8 @@ services:
       CP_MONITOR_CP_ID: CP-010
       CP_MONITOR_CP_E_HOST: ev-cp-e-10
       CP_MONITOR_CP_E_PORT: 8010
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 2.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -500,11 +500,11 @@ services:
     container_name: ev-driver-alice
     environment:
       DRIVER_DRIVER_ID: driver-alice
-      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 5.0
       DRIVER_LOG_LEVEL: INFO
       DRIVER_DASHBOARD_PORT: 8100
-      DRIVER_CENTRAL_HTTP_URL: http://ev-central:8000
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ./requests.txt:/app/requests.txt:ro
     ports:
@@ -525,11 +525,11 @@ services:
     container_name: ev-driver-bob
     environment:
       DRIVER_DRIVER_ID: driver-bob
-      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 6.0
       DRIVER_LOG_LEVEL: INFO
       DRIVER_DASHBOARD_PORT: 8101
-      DRIVER_CENTRAL_HTTP_URL: http://ev-central:8000
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ./requests.txt:/app/requests.txt:ro
     ports:
@@ -550,11 +550,11 @@ services:
     container_name: ev-driver-charlie
     environment:
       DRIVER_DRIVER_ID: driver-charlie
-      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 7.0
       DRIVER_LOG_LEVEL: INFO
       DRIVER_DASHBOARD_PORT: 8102
-      DRIVER_CENTRAL_HTTP_URL: http://ev-central:8000
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ./requests.txt:/app/requests.txt:ro
     ports:
@@ -575,11 +575,11 @@ services:
     container_name: ev-driver-david
     environment:
       DRIVER_DRIVER_ID: driver-david
-      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 8.0
       DRIVER_LOG_LEVEL: INFO
       DRIVER_DASHBOARD_PORT: 8103
-      DRIVER_CENTRAL_HTTP_URL: http://ev-central:8000
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ./requests.txt:/app/requests.txt:ro
     ports:
@@ -600,11 +600,11 @@ services:
     container_name: ev-driver-eve
     environment:
       DRIVER_DRIVER_ID: driver-eve
-      DRIVER_KAFKA_BOOTSTRAP: kafka:9092
+      DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 4.5
       DRIVER_LOG_LEVEL: INFO
       DRIVER_DASHBOARD_PORT: 8104
-      DRIVER_CENTRAL_HTTP_URL: http://ev-central:8000
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ./requests.txt:/app/requests.txt:ro
     ports:

--- a/docker/docker-compose.remote-kafka.yml
+++ b/docker/docker-compose.remote-kafka.yml
@@ -66,8 +66,8 @@ services:
       CP_MONITOR_CP_ID: CP-001
       CP_MONITOR_CP_E_HOST: ev-cp-e-1
       CP_MONITOR_CP_E_PORT: 8001
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 1.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -87,8 +87,8 @@ services:
       CP_MONITOR_CP_ID: CP-002
       CP_MONITOR_CP_E_HOST: ev-cp-e-2
       CP_MONITOR_CP_E_PORT: 8001
-      CP_MONITOR_CENTRAL_HOST: ev-central
-      CP_MONITOR_CENTRAL_PORT: 8000
+      CP_MONITOR_CENTRAL_HOST: ${CENTRAL_HOST:-ev-central}
+      CP_MONITOR_CENTRAL_PORT: ${CENTRAL_PORT:-8000}
       CP_MONITOR_HEALTH_INTERVAL: 1.0
       CP_MONITOR_LOG_LEVEL: INFO
     depends_on:
@@ -109,6 +109,7 @@ services:
       DRIVER_KAFKA_BOOTSTRAP: ${KAFKA_BOOTSTRAP:-kafka:9092}
       DRIVER_REQUEST_INTERVAL: 4.0
       DRIVER_LOG_LEVEL: INFO
+      DRIVER_CENTRAL_HTTP_URL: ${CENTRAL_HTTP_URL:-http://ev-central:8000}
     volumes:
       - ../requests.txt:/app/requests.txt:ro
     depends_on:

--- a/wait-for-kafka.sh
+++ b/wait-for-kafka.sh
@@ -4,19 +4,35 @@
 
 set -e
 
-host="$1"
-shift
+host_arg="${1:-}"
+[ -n "$host_arg" ] && shift || true
+
+# Resolve bootstrap host/port from available environment variables.
+# Preference order allows per-service overrides while keeping backwards compatibility
+# with the original hard-coded host.
+bootstrap_target="${KAFKA_BOOTSTRAP:-${CENTRAL_KAFKA_BOOTSTRAP:-${CP_ENGINE_KAFKA_BOOTSTRAP:-${CP_MONITOR_KAFKA_BOOTSTRAP:-${DRIVER_KAFKA_BOOTSTRAP:-${host_arg:-kafka:9092}}}}}}"
+
+# Some services (e.g., CP monitors) may only specify a Central host/port. Fall back to that
+# when no Kafka bootstrap is configured.
+if [ "$bootstrap_target" = "kafka:9092" ] && [ -n "$CP_MONITOR_CENTRAL_HOST" ]; then
+  bootstrap_target="${CP_MONITOR_CENTRAL_HOST}:${CP_MONITOR_CENTRAL_PORT:-8000}"
+fi
+
+# Split host/port for nc checks
+wait_host="${bootstrap_target%%:*}"
+wait_port="${bootstrap_target##*:}"
+
 max_attempts="${KAFKA_WAIT_MAX_ATTEMPTS:-30}"
 wait_seconds="${KAFKA_WAIT_SECONDS:-2}"
 
-echo "⏳ Waiting for Kafka at $host to be ready..."
+echo "⏳ Waiting for service at ${wait_host}:${wait_port} to be ready..."
 echo "   Max attempts: $max_attempts, Wait interval: ${wait_seconds}s"
 
 attempt=0
-until nc -z ${host%%:*} ${host##*:} 2>/dev/null; do
+until nc -z "$wait_host" "$wait_port" 2>/dev/null; do
   attempt=$((attempt + 1))
   if [ $attempt -ge $max_attempts ]; then
-    echo "❌ Kafka at $host did not become available after $max_attempts attempts"
+    echo "❌ Service at ${wait_host}:${wait_port} did not become available after $max_attempts attempts"
     exit 1
   fi
   
@@ -27,7 +43,7 @@ until nc -z ${host%%:*} ${host##*:} 2>/dev/null; do
   sleep $wait_seconds
 done
 
-echo "✅ Kafka at $host is ready!"
+echo "✅ Service at ${wait_host}:${wait_port} is ready!"
 echo "🚀 Starting application: $@"
 
 exec "$@"


### PR DESCRIPTION
## Summary
- allow every service to consume Kafka/Central host overrides from environment variables in docker-compose files
- make the Kafka readiness wrapper detect the correct remote host before launching services

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd0a7624c88323a5a117053478ec3d